### PR TITLE
remove unnecessary code

### DIFF
--- a/test.py
+++ b/test.py
@@ -41,16 +41,6 @@ default_dataset_fraction = 1.0
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
 
-# code to query nvidia tools
-def choose_gpu_by_free_vram():
-    mem_free = subprocess.check_output(["nvidia-smi", "--format=csv,noheader,nounits", "--query-gpu=memory.free"])
-    mem_free_per_gpu = list(map(int, mem_free.decode('utf-8').strip().split('\n')))
-
-    gpu = max(range(len(mem_free_per_gpu)), key=lambda i: mem_free_per_gpu[i])
-
-    return gpu
-
-
 # main code
 def compute_metrics(eval_pred, tokenizer, exact_match_metric, f1_metric, bleu_metric):
     logits, labels = eval_pred
@@ -255,12 +245,7 @@ def test(model_name: str, batch_size: int, dataset_fraction: float):
     os.environ["WANDB_MODE"] = "offline"
 
     # initialize torch device
-    if torch.cuda.is_available():
-        gpu_index = choose_gpu_by_free_vram()
-        device = torch.device(f"cuda:{gpu_index}")
-    else:
-        device = torch.device("cpu")
-
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     print(f"using device {device}")
 
     # load metrics


### PR DESCRIPTION
Sorry for adding these changes. It works on the test machine but not with the batch system.

---

The available GPUs are restricted by the run script provided by the RZ. If we query all GPUs using nvidia-smi, we receive some that are not even available from within our python script. Just let pytorch use the first which is defined by the batch job management system.